### PR TITLE
added color for .bk-tip

### DIFF
--- a/bokehjs/src/less/toolbar.less
+++ b/bokehjs/src/less/toolbar.less
@@ -186,6 +186,7 @@
         .bk-toolbar-button {
           .bk-tip {
              float: right;
+             color: #999999;
           }
         }
       }


### PR DESCRIPTION
...for users who are implementing charts on top of css where the font color is assigned something that clashes with the look of the chart.

i.e. white font declared by outside css will make tooltips invisible until now

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [1] issues: fixes #5725
- [1] tests added / passed
- [0] release document entry (if new feature or API change)
